### PR TITLE
Use username in offline mode

### DIFF
--- a/src/main/java/com/sk89q/mclauncher/AddonInstallerTask.java
+++ b/src/main/java/com/sk89q/mclauncher/AddonInstallerTask.java
@@ -71,6 +71,7 @@ public class AddonInstallerTask extends Task {
         boolean foundClasses = false;
         String mungePath = null;
         boolean multipleMunge = false;
+        boolean hasMcmodInfo = false;
 
         Pattern classRE = Pattern.compile("^.*\\.class$");
         Pattern modLoaderNameRE = Pattern.compile("^(?:.*/)?mod_([A-Za-z0-9_]+)\\.class$");
@@ -94,12 +95,9 @@ public class AddonInstallerTask extends Task {
                 entriesCount++;
                 
                 String path = entry.getName().replace("\\", "/"); // Normalize
-                // FML's mcmod.info authoritively implies munge path
-                // see https://github.com/cpw/FML/wiki/FML-mod-information-file
-                if (path.equals("mcmod.info")) {
-                    mungePath = null;
-                    break;
-                }
+                // FML's mcmod.info = no munging, see https://github.com/cpw/FML/wiki/FML-mod-information-file
+                if (path.equals("mcmod.info"))
+                    hasMcmodInfo = true;
 
                 if (path.startsWith("/"))
                     continue; // Invalid file!
@@ -174,11 +172,11 @@ public class AddonInstallerTask extends Task {
         }
 
         // Do we munge?
-        boolean needToMunge = !hasRoot && mungePath != null && !multipleMunge;
+        boolean needToMunge = !hasMcmodInfo && !hasRoot && mungePath != null && !multipleMunge;
 
         // If we have multiple munge paths, we best do nothing
         // Maybe we'll try munging anyway in the future
-        if (multipleMunge) {
+        if (multipleMunge && !hasMcmodInfo) {
             try {
                 SwingUtilities.invokeAndWait(new Runnable() {
                     @Override

--- a/src/main/java/com/sk89q/mclauncher/AddonInstallerTask.java
+++ b/src/main/java/com/sk89q/mclauncher/AddonInstallerTask.java
@@ -94,19 +94,10 @@ public class AddonInstallerTask extends Task {
                 entriesCount++;
                 
                 String path = entry.getName().replace("\\", "/"); // Normalize
-
                 // FML's mcmod.info authoritively implies munge path
-                if (path.endsWith("mcmod.info")) {
-                    int lastSlash = path.lastIndexOf('/');
-                    if (lastSlash == -1) {
-                        System.out.println("Found mcmod.info at root, not munging");
-                        mungePath = null;
-                        break;
-                    }
-                    // TODO: can this happen, or is mcmod.info only at /? 
-                    // https://github.com/cpw/FML/wiki/FML-mod-information-file just says "Inside a mod jar file it should always be named mcmod.info"
-                    mungePath = path.substring(0, lastSlash + 1);
-                    System.out.println("Found mcmod.info at '"+path+"' munging to '"+mungePath+"'");
+                // see https://github.com/cpw/FML/wiki/FML-mod-information-file
+                if (path.equals("mcmod.info")) {
+                    mungePath = null;
                     break;
                 }
 

--- a/src/main/java/com/sk89q/mclauncher/AddonInstallerTask.java
+++ b/src/main/java/com/sk89q/mclauncher/AddonInstallerTask.java
@@ -94,7 +94,22 @@ public class AddonInstallerTask extends Task {
                 entriesCount++;
                 
                 String path = entry.getName().replace("\\", "/"); // Normalize
-                
+
+                // FML's mcmod.info authoritively implies munge path
+                if (path.endsWith("mcmod.info")) {
+                    int lastSlash = path.lastIndexOf('/');
+                    if (lastSlash == -1) {
+                        System.out.println("Found mcmod.info at root, not munging");
+                        mungePath = null;
+                        break;
+                    }
+                    // TODO: can this happen, or is mcmod.info only at /? 
+                    // https://github.com/cpw/FML/wiki/FML-mod-information-file just says "Inside a mod jar file it should always be named mcmod.info"
+                    mungePath = path.substring(0, lastSlash + 1);
+                    System.out.println("Found mcmod.info at '"+path+"' munging to '"+mungePath+"'");
+                    break;
+                }
+
                 if (path.startsWith("/"))
                     continue; // Invalid file!
                 

--- a/src/main/java/com/sk89q/mclauncher/LaunchTask.java
+++ b/src/main/java/com/sk89q/mclauncher/LaunchTask.java
@@ -185,7 +185,7 @@ public class LaunchTask extends Task {
         }
         
         // Read some settings
-        String username = playOffline ? "Player" : this.username;
+        String username = this.username;
         String runtimePath = Util.nullEmpty(settings.get(Def.JAVA_RUNTIME));
         String wrapperPath = Util.nullEmpty(settings.get(Def.JAVA_WRAPPER_PROGRAM));
         int minMem = settings.getInt(Def.JAVA_MIN_MEM, 128);


### PR DESCRIPTION
Sends the user's username as specified instead of Player when connecting in offline mode. 

Useful when Minecraft's login server is down (like it is right now) and you want to get to your server, or for testing with multiple players (besides your real account and Player).

Maybe this could be made into a config option if logging in as Player by default is desirable.. but this pull request just always sends the username the user specified. Other launchers do the same (e.g. Magic Launcher) with no problems..
