### PR TITLE
Prevent munging if FML mcmod.info is present in root of mod jar.

### DIFF
--- a/src/main/java/com/sk89q/mclauncher/AddonInstallerTask.java
+++ b/src/main/java/com/sk89q/mclauncher/AddonInstallerTask.java
@@ -95,6 +95,13 @@ public class AddonInstallerTask extends Task {
                 
                 String path = entry.getName().replace("\\", "/"); // Normalize
                 
+                // FML's mcmod.info authoritively implies no munging
+                // see https://github.com/cpw/FML/wiki/FML-mod-information-file
+                if (path.equals("mcmod.info")) {
+                    mungePath = null;
+                    break;
+                }
+                
                 if (path.startsWith("/"))
                     continue; // Invalid file!
                 


### PR DESCRIPTION
Fixes loading mods which have their mod_ class in their own package (e.g. Iron Chests, no longer fails with  java.lang.NoClassDefFoundError: mod_IronChest (wrong name: cpw/mods/ironchest/mod_IronChest) https://gist.github.com/c8b38490f7f1b1b47d14)
