### PR TITLE
Show a button to load news when "Don't load the news" is selected in options.

### DIFF
--- a/src/main/java/com/sk89q/mclauncher/LauncherFrame.java
+++ b/src/main/java/com/sk89q/mclauncher/LauncherFrame.java
@@ -107,7 +107,7 @@ public class LauncherFrame extends JFrame {
     public LauncherFrame() {
         setTitle("SK's Minecraft Launcher");
         setSize(620, 500);
-        setLocationRelativeTo(null);
+        
         setDefaultCloseOperation(DISPOSE_ON_CLOSE);
 
         try {
@@ -127,6 +127,8 @@ public class LauncherFrame extends JFrame {
         options = Launcher.getInstance().getOptions();
 
         buildUI();
+        
+        setLocationRelativeTo(null);
 
         // Setup
         setConfiguration(options.getStartupConfiguration());
@@ -355,43 +357,50 @@ public class LauncherFrame extends JFrame {
         final LauncherFrame self = this;
 
         setLayout(new BorderLayout(0, 0));
-
-        if (options.getSettings().getBool(Def.LAUNCHER_NO_NEWS, false)) {
-            final JLayeredPane newsPanel = new JLayeredPane();
-            
-            newsPanel.setBorder(new CompoundBorder(BorderFactory
-                    .createEmptyBorder(PAD, 0, PAD, PAD), new CompoundBorder(
-                    BorderFactory.createEtchedBorder(), BorderFactory
-                            .createEmptyBorder(4, 4, 4, 4))));
-            newsPanel.setLayout(new BoxLayout(newsPanel, BoxLayout.Y_AXIS));
-            
-            final JButton showNews = new JButton("Show news");
-            showNews.setAlignmentX(Component.CENTER_ALIGNMENT);
-            showNews.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    showNews.setVisible(false);
-                    showNews(newsPanel);
-                }
-            });
-            
-            // Center the button vertically.
-            newsPanel.add(new Box.Filler(new Dimension(0,0), 
-                    new Dimension(0,0), new Dimension(1000,1000)));
-            newsPanel.add(showNews);
-            newsPanel.add(new Box.Filler(new Dimension(0,0), 
-                    new Dimension(0,0), new Dimension(1000,1000)));
-            
-            add(newsPanel, BorderLayout.CENTER);
-        } else {
-            JLayeredPane newsPanel = new JLayeredPane();
-            showNews(newsPanel);
-            add(newsPanel, BorderLayout.CENTER);
+        boolean hidenews = options.getSettings().getBool(Def.LAUNCHER_HIDE_NEWS, false);
+        
+        if (!hidenews) {
+            if (options.getSettings().getBool(Def.LAUNCHER_NO_NEWS, false)) {
+                final JLayeredPane newsPanel = new JLayeredPane();
+                
+                newsPanel.setBorder(new CompoundBorder(BorderFactory
+                        .createEmptyBorder(PAD, 0, PAD, PAD), new CompoundBorder(
+                        BorderFactory.createEtchedBorder(), BorderFactory
+                                .createEmptyBorder(4, 4, 4, 4))));
+                newsPanel.setLayout(new BoxLayout(newsPanel, BoxLayout.Y_AXIS));
+                
+                final JButton showNews = new JButton("Show news");
+                showNews.setAlignmentX(Component.CENTER_ALIGNMENT);
+                showNews.addActionListener(new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        showNews.setVisible(false);
+                        showNews(newsPanel);
+                    }
+                });
+                
+                // Center the button vertically.
+                newsPanel.add(new Box.Filler(new Dimension(0,0), 
+                        new Dimension(0,0), new Dimension(1000,1000)));
+                newsPanel.add(showNews);
+                newsPanel.add(new Box.Filler(new Dimension(0,0), 
+                        new Dimension(0,0), new Dimension(1000,1000)));
+                
+                add(newsPanel, BorderLayout.CENTER);
+            } else {
+                JLayeredPane newsPanel = new JLayeredPane();
+                showNews(newsPanel);
+                add(newsPanel, BorderLayout.CENTER);
+            }
         }
         
         JPanel leftPanel = new JPanel();
-        leftPanel.setLayout(new BorderLayout(0, 0));
-        add(leftPanel, BorderLayout.LINE_START);
+        leftPanel.setLayout(new BorderLayout());
+        if (!hidenews) {
+            add(leftPanel, BorderLayout.LINE_START);
+        } else {
+            add(leftPanel, BorderLayout.CENTER);
+        }
 
         JPanel buttonsPanel = new JPanel();
         buttonsPanel.setLayout(new GridLayout(1, 3, 3, 0));
@@ -465,6 +474,10 @@ public class LauncherFrame extends JFrame {
                 openAddons();
             }
         });
+        
+        if (hidenews) {
+            setSize(300, 500);
+        }
     }
 
     /**

--- a/src/main/java/com/sk89q/mclauncher/LauncherFrame.java
+++ b/src/main/java/com/sk89q/mclauncher/LauncherFrame.java
@@ -324,6 +324,29 @@ public class LauncherFrame extends JFrame {
         dialog.setVisible(true);
         return dialog;
     }
+    
+    private void showNews(JLayeredPane newsPanel) {
+        final LauncherFrame self = this;
+        newsPanel.setLayout(new NewsLayoutManager());
+        newsPanel
+            .setBorder(BorderFactory.createEmptyBorder(PAD, 0, PAD, PAD));
+        JEditorPane newsView = new JEditorPane();
+        newsView.setEditable(false);
+        newsView.addHyperlinkListener(new HyperlinkListener() {
+            @Override
+            public void hyperlinkUpdate(HyperlinkEvent e) {
+                if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+                    UIUtil.openURL(e.getURL(), self);
+                }
+            }
+        });
+        JScrollPane newsScroll = new JScrollPane(newsView);
+        newsPanel.add(newsScroll, new Integer(1));
+        JProgressBar newsProgress = new JProgressBar();
+        newsProgress.setIndeterminate(true);
+        newsPanel.add(newsProgress, new Integer(2));
+        NewsFetcher.update(newsView, newsProgress);
+    }
 
     /**
      * Build the UI.
@@ -334,36 +357,36 @@ public class LauncherFrame extends JFrame {
         setLayout(new BorderLayout(0, 0));
 
         if (options.getSettings().getBool(Def.LAUNCHER_NO_NEWS, false)) {
-            JPanel newsPanel = new JPanel();
+            final JLayeredPane newsPanel = new JLayeredPane();
+            
             newsPanel.setBorder(new CompoundBorder(BorderFactory
                     .createEmptyBorder(PAD, 0, PAD, PAD), new CompoundBorder(
                     BorderFactory.createEtchedBorder(), BorderFactory
                             .createEmptyBorder(4, 4, 4, 4))));
             newsPanel.setLayout(new BoxLayout(newsPanel, BoxLayout.Y_AXIS));
-            newsPanel.add(new JLabel("Re-enable news in Options."));
+            
+            final JButton showNews = new JButton("Show news");
+            showNews.setAlignmentX(Component.CENTER_ALIGNMENT);
+            showNews.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    showNews.setVisible(false);
+                    showNews(newsPanel);
+                }
+            });
+            
+            // Center the button vertically.
+            newsPanel.add(new Box.Filler(new Dimension(0,0), 
+                    new Dimension(0,0), new Dimension(1000,1000)));
+            newsPanel.add(showNews);
+            newsPanel.add(new Box.Filler(new Dimension(0,0), 
+                    new Dimension(0,0), new Dimension(1000,1000)));
+            
             add(newsPanel, BorderLayout.CENTER);
         } else {
             JLayeredPane newsPanel = new JLayeredPane();
-            newsPanel.setLayout(new NewsLayoutManager());
-            newsPanel
-                    .setBorder(BorderFactory.createEmptyBorder(PAD, 0, PAD, PAD));
-            JEditorPane newsView = new JEditorPane();
-            newsView.setEditable(false);
-            newsView.addHyperlinkListener(new HyperlinkListener() {
-                @Override
-                public void hyperlinkUpdate(HyperlinkEvent e) {
-                    if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
-                        UIUtil.openURL(e.getURL(), self);
-                    }
-                }
-            });
-            JScrollPane newsScroll = new JScrollPane(newsView);
-            newsPanel.add(newsScroll, new Integer(1));
-            JProgressBar newsProgress = new JProgressBar();
-            newsProgress.setIndeterminate(true);
-            newsPanel.add(newsProgress, new Integer(2));
+            showNews(newsPanel);
             add(newsPanel, BorderLayout.CENTER);
-            NewsFetcher.update(newsView, newsProgress);
         }
         
         JPanel leftPanel = new JPanel();

--- a/src/main/java/com/sk89q/mclauncher/LauncherOptionsPanel.java
+++ b/src/main/java/com/sk89q/mclauncher/LauncherOptionsPanel.java
@@ -35,6 +35,7 @@ public class LauncherOptionsPanel extends OptionsPanel {
     protected void buildControls() {
         createFieldGroup("Launcher");
         addField(Def.LAUNCHER_NO_NEWS, new JCheckBox("Don't load the news"));
+        addField(Def.LAUNCHER_HIDE_NEWS, new JCheckBox("Hide the news panel"));
         addField(Def.LAUNCHER_ALWAYS_MORE_OPTIONS, new JCheckBox("Start with all options shown"));
         addField(Def.LAUNCHER_REOPEN, new JCheckBox("Show the launcher on Minecraft close"));
 

--- a/src/main/java/com/sk89q/mclauncher/config/Def.java
+++ b/src/main/java/com/sk89q/mclauncher/config/Def.java
@@ -30,6 +30,7 @@ public class Def {
     public static final String COLORED_CONSOLE = "console.colored";
     public static final String CONSOLE_KILLS_PROCESS = "console.kill-process";
     public static final String LAUNCHER_NO_NEWS = "launcher.newsless";
+    public static final String LAUNCHER_HIDE_NEWS = "launcher.hidenews";
     public static final String LAUNCHER_ALWAYS_MORE_OPTIONS = "launcher.always-more-options";
     public static final String LAUNCHER_REOPEN = "launcher.reopen";
     public static final String WINDOW_WIDTH = "window.width";

--- a/src/main/resources/defaults.xml
+++ b/src/main/resources/defaults.xml
@@ -11,6 +11,7 @@
     <setting key="java.wrapper-program"/>
     <setting key="launcher.always-more-options">false</setting>
     <setting key="launcher.newsless">false</setting>
+    <setting key="launcher.hidenews">false</setting>
     <setting key="launcher.reopen">false</setting>
     <setting key="lwjgl.debug">false</setting>
     <setting key="window.fullscreen">false</setting>


### PR DESCRIPTION
Instead of the "Re-enabled news in options" text, a "Load news" button is displayed centered in the news panel. This implements issue #3. This also implements a third option of hiding the news panel entirely.
