### PR TITLE
Backup the main minecraft jar when updating, if enabled.

### DIFF
--- a/src/main/java/com/sk89q/mclauncher/LaunchTask.java
+++ b/src/main/java/com/sk89q/mclauncher/LaunchTask.java
@@ -636,6 +636,24 @@ public class LaunchTask extends Task {
      */
     private void update(File rootDir, UpdateCache cache, InputStream packageStream,
             boolean forced, String username, String ticket) throws ExecutionException {
+        if (Launcher.getInstance().getOptions().getSettings().getBool(
+                Def.BACKUP_MINEJAR, true)) {
+            File source = new File(rootDir, "bin/minecraft.jar");
+            File dest = new File(rootDir, "bin/minecraft-" + 
+                    Util.getMCVersion(source) + ".jar");
+
+            if (source.exists() && !dest.exists()) {
+                fireTitleChange("Backing up...");
+                fireStatusChange("Backing up minecraft.jar...");
+
+                try {
+                    Util.copyFile(source, dest);
+                } catch (IOException ex) {
+                    logger.severe(Util.getStackTrace(ex));
+                }
+            }
+        }
+        
         fireTitleChange("Updating Minecraft...");
         
         updater = new Updater(packageStream, rootDir, cache);

--- a/src/main/java/com/sk89q/mclauncher/LauncherOptionsPanel.java
+++ b/src/main/java/com/sk89q/mclauncher/LauncherOptionsPanel.java
@@ -46,6 +46,9 @@ public class LauncherOptionsPanel extends OptionsPanel {
 
         createFieldGroup("Addons");
         addField(Def.FAST_TEST, new JCheckBox("Addon test uses offline mode"));
+        
+        createFieldGroup("Updates");
+        addField(Def.BACKUP_MINEJAR, new JCheckBox("Backup minecraft.jar"));
     }
 
 }

--- a/src/main/java/com/sk89q/mclauncher/config/Def.java
+++ b/src/main/java/com/sk89q/mclauncher/config/Def.java
@@ -33,6 +33,7 @@ public class Def {
     public static final String LAUNCHER_ALLOW_OFFLINE_NAME = "launcher.allowofflinename";
     public static final String LAUNCHER_HIDE_NEWS = "launcher.hidenews";
     public static final String LAUNCHER_REOPEN = "launcher.reopen";
+    public static final String BACKUP_MINEJAR = "updates.backupminejar";
     public static final String WINDOW_WIDTH = "window.width";
     public static final String WINDOW_HEIGHT = "window.height";
     public static final String WINDOW_FULLSCREEN = "window.fullscreen";

--- a/src/main/resources/defaults.xml
+++ b/src/main/resources/defaults.xml
@@ -12,6 +12,7 @@
     <setting key="launcher.newsless">false</setting>
     <setting key="launcher.hidenews">false</setting>
     <setting key="launcher.reopen">false</setting>
+    <setting key="updates.backupminejar">true</setting>
     <setting key="lwjgl.debug">false</setting>
     <setting key="window.fullscreen">false</setting>
     <setting key="window.height">480</setting>


### PR DESCRIPTION
Implements part of issue #24.
