### PR TITLE
Increased number of versions that SKMCLauncher now recognises

### DIFF
--- a/src/main/java/com/sk89q/mclauncher/util/Util.java
+++ b/src/main/java/com/sk89q/mclauncher/util/Util.java
@@ -246,7 +246,7 @@ public class Util {
      */
     public static String getMCVersion(File file) {
         String prefix = "Minecraft Minecraft ";
-        Pattern magic = Pattern.compile("(" + prefix + "(\\w|\\.)+(?=\01\00))");
+        Pattern magic = Pattern.compile("(" + prefix + "(\\w|\\.|\\s)+(?=\01\00))");
         String version = "Unknown";
         try {
             JarFile jar = new JarFile(file);

--- a/src/main/java/com/sk89q/mclauncher/util/Util.java
+++ b/src/main/java/com/sk89q/mclauncher/util/Util.java
@@ -246,7 +246,7 @@ public class Util {
      */
     public static String getMCVersion(File file) {
         String prefix = "Minecraft Minecraft ";
-        Pattern magic = Pattern.compile("(" + prefix + "(\\w|\\.|\\s)+(?=\01\00))");
+        Pattern magic = Pattern.compile("(" + prefix + "(\\w|\\.|\\s|\\p{Punct})+(?=\01\00))");
         String version = "Unknown";
         try {
             JarFile jar = new JarFile(file);


### PR DESCRIPTION
Version strings earlier than minecraft-1.0.0 weren't being picked up, so I took a look and added to the regex. Now versions from Alpha_1.0.11 are being picked up correctly, even the PCGamer's demo. The one wrinkle with this patch? the GUI doesn't "look" right any more as the Active Jar dropdown now spans further than it used to.

Finally managed to remove a merge request of mine that probably shouldn't have been in the bucket by the simple expediency of doing a git reset --hard to the stage previous to the merge, then doing the two additional patterns again.

Enjoy.
