### PR TITLE
Correcting a NPE where the user had no .minecraft whatsoever.

### DIFF
--- a/src/main/java/com/sk89q/mclauncher/config/Configuration.java
+++ b/src/main/java/com/sk89q/mclauncher/config/Configuration.java
@@ -304,10 +304,10 @@ public class Configuration {
         List<MinecraftJar> jars = new ArrayList<MinecraftJar>();
         jars.add(new MinecraftJar(new File(base, "minecraft.jar")));
         File[] files = base.listFiles();
-        Arrays.sort(files);
         if (files == null) {
             return jars;
         }
+        Arrays.sort(files);
         for (File f : files) {
             String name = f.getName();
             


### PR DESCRIPTION
I saw a bug report (thankfully a stacktrace) that indicated that Arrays.sort() doesn't like empty File[]. base.listFiles() doesn't guarantee that it'll even fill the array if there's no files in the directory (for example, .minecraft doesn't exist). I've shifted the Array.sort after the "Is files == null" check . I should have caught this, but I'm glad I have caught it now. This should fix bug #42 and make for happy people.

Regards, The Viking (Dr Smokey)
