### PR TITLE
Fix flag parsing to allow non-counting leftover args before flags

### DIFF
--- a/src/main/java/com/sk89q/mclauncher/util/BasicArgsParser.java
+++ b/src/main/java/com/sk89q/mclauncher/util/BasicArgsParser.java
@@ -42,19 +42,12 @@ public class BasicArgsParser {
         List<String> leftOver = new ArrayList<String>();
         Set<String> flags = new HashSet<String>();
         Map<String, String> values = new HashMap<String, String>();
-        
-        boolean processingFlags = true;
+
         String wantingFlag = null;
-        
+
         for (int i = 0; i < args.length; i++) {
             String arg = args[i];
             if (arg.startsWith("-")) {
-                if (!processingFlags) {
-                    throw new IllegalArgumentException("Flags must come first");
-                }
-                if (arg.length() == 1) {
-                    throw new IllegalArgumentException("Flag with no name");
-                }
                 String flag = arg.substring(1);
                 if (valueArgs.contains(flag)) {
                     wantingFlag = flag;
@@ -67,7 +60,6 @@ public class BasicArgsParser {
                 values.put(wantingFlag, arg);
                 wantingFlag = null;
             } else {
-                processingFlags = false;
                 leftOver.add(arg);
             }
         }

--- a/src/main/java/com/sk89q/mclauncher/util/BasicArgsParser.java
+++ b/src/main/java/com/sk89q/mclauncher/util/BasicArgsParser.java
@@ -48,6 +48,9 @@ public class BasicArgsParser {
         for (int i = 0; i < args.length; i++) {
             String arg = args[i];
             if (arg.startsWith("-")) {
+				if (arg.length() == 1) {
+					throw new IllegalArgumentException("Flag with no name");
+				}
                 String flag = arg.substring(1);
                 if (valueArgs.contains(flag)) {
                     wantingFlag = flag;

--- a/src/main/java/com/sk89q/mclauncher/util/BasicArgsParser.java
+++ b/src/main/java/com/sk89q/mclauncher/util/BasicArgsParser.java
@@ -48,9 +48,9 @@ public class BasicArgsParser {
         for (int i = 0; i < args.length; i++) {
             String arg = args[i];
             if (arg.startsWith("-")) {
-				if (arg.length() == 1) {
-					throw new IllegalArgumentException("Flag with no name");
-				}
+                if (arg.length() == 1) {
+                    throw new IllegalArgumentException("Flag with no name");
+                }
                 String flag = arg.substring(1);
                 if (valueArgs.contains(flag)) {
                     wantingFlag = flag;


### PR DESCRIPTION
I went ahead and fixed the issue I was talking about. Now a command like the following:

```
skmclauncher.exe "" "" 127.0.0.1 -address 127.0.0.1 -launch
```

will put "", "", and 127.0.0.1 into leftOver and parse the -address value and the -launch flag.

In doing this, I removed the logic for forcing flags to be placed first (obviously) and the boolean "processingFlags". As far as I could tell, this had no purpose, but if it did, feel free to reject the pull request.

(This is my first pull request ever, for any project, so let me know if I'm doing it wrong!)
